### PR TITLE
add macro: build_math_fn, implement math: add sub mul

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,19 @@ SPDX-License-Identifier: AGPL-3.0-only
   - [x] Function (without destructuring and ellipsis)
   - [x] Function Application
   - [x] Deferred Values (Laziness)
+  - [ ] Control flow (if then else)
 - Built-ins:
-  - [x] Addition (+)
-  - [x] Subtraction (-)
-  - [x] Multiplication (*)
+  - Binary operators:
+    - [x] Addition (+)
+    - [x] Subtraction (-)
+    - [x] Multiplication (*)
+    - [ ] Division (/)
+    - [ ] Concatenation (++)
+    - [ ] EqualTo (==)
+    - ...
+  - Unary operators:
+    - [ ] Negation (-)
+    - [ ] Not (!)
 - Store interface:
   - [ ] Rust trait
 - Store implementations:

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ SPDX-License-Identifier: AGPL-3.0-only
   - [x] Deferred Values (Laziness)
 - Built-ins:
   - [x] Addition (+)
+  - [x] Subtraction (-)
+  - [x] Multiplication (*)
 - Store interface:
   - [ ] Rust trait
 - Store implementations:

--- a/src/interpreter/value.rs
+++ b/src/interpreter/value.rs
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 use std::rc::Rc;
+use std::collections::LinkedList;
 
 use nixel::ast::BinaryOperator;
 use nixel::ast::UnaryOperator;
+use nixel::ast::StringPart;
 use nixel::ast::AST;
 
 use super::location::Location;
@@ -75,6 +77,9 @@ pub(crate) enum Value {
         location:   Location,
         scope:      Scope,
     },
+    String {
+        parts: LinkedList<StringPart>,
+    }
 }
 
 impl Value {
@@ -127,6 +132,12 @@ impl Value {
                 )
             }
 
+            /*
+            AST::IfThenElse { predicate, then, else_, position } => {
+                // ...
+            }
+            */
+
             AST::Function { argument, definition, .. } => {
                 Value::Function {
                     bind_to: argument,
@@ -151,6 +162,8 @@ impl Value {
             }
 
             AST::Int { value, .. } => Value::Int(value),
+
+            AST::String { parts, .. } => Value::String { parts },
 
             AST::LetIn { bindings, target, position: _ } => {
                 let bindings = Bindings::new(bindings);
@@ -198,6 +211,7 @@ impl Value {
             Value::FunctionApplication { .. } => "FunctionApplication",
             Value::Int { .. } => "Int",
             Value::Variable { .. } => "Variable",
+            Value::String { .. } => "String",
         }
     }
 }

--- a/tests/built_in_*/overflow/cli.args
+++ b/tests/built_in_*/overflow/cli.args
@@ -1,0 +1,2 @@
+eval
+tests/built_in_*/overflow/input.nix

--- a/tests/built_in_*/overflow/input.nix
+++ b/tests/built_in_*/overflow/input.nix
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2022 Kevin Amado <kamadorueda@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+9223372036854775807 * 2

--- a/tests/built_in_*/overflow/output.log
+++ b/tests/built_in_*/overflow/output.log
@@ -1,0 +1,11 @@
+[ERROR]: Interpreter error, most recent action last:
+
+At "tests/built_in_*/overflow/input.nix", evaluating "built-in *"
+  > 5 | 9223372036854775807 * 2
+                            ^
+
+At "tests/built_in_*/overflow/input.nix", integer overflow while multiplying 9223372036854775807 and 2
+  > 5 | 9223372036854775807 * 2
+                            ^
+
+

--- a/tests/built_in_*/success/cli.args
+++ b/tests/built_in_*/success/cli.args
@@ -1,0 +1,2 @@
+eval
+tests/built_in_*/success/input.nix

--- a/tests/built_in_*/success/input.nix
+++ b/tests/built_in_*/success/input.nix
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2022 Kevin Amado <kamadorueda@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+2 * 3

--- a/tests/built_in_*/success/output.log
+++ b/tests/built_in_*/success/output.log
@@ -1,0 +1,3 @@
+[INFO]: value = Int(
+    6,
+)

--- a/tests/built_in_-/overflow/cli.args
+++ b/tests/built_in_-/overflow/cli.args
@@ -1,0 +1,2 @@
+eval
+tests/built_in_-/overflow/input.nix

--- a/tests/built_in_-/overflow/input.nix
+++ b/tests/built_in_-/overflow/input.nix
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2022 Kevin Amado <kamadorueda@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+0 - 9223372036854775807 - 2

--- a/tests/built_in_-/overflow/output.log
+++ b/tests/built_in_-/overflow/output.log
@@ -1,0 +1,15 @@
+[ERROR]: Interpreter error, most recent action last:
+
+At "tests/built_in_-/overflow/input.nix", evaluating "built-in -"
+  > 5 | 0 - 9223372036854775807 - 2
+                                ^
+
+At "tests/built_in_-/overflow/input.nix", evaluating "built-in -"
+  > 5 | 0 - 9223372036854775807 - 2
+          ^
+
+At "tests/built_in_-/overflow/input.nix", integer overflow while subtracting -9223372036854775807 and 2
+  > 5 | 0 - 9223372036854775807 - 2
+                                ^
+
+

--- a/tests/built_in_-/success/cli.args
+++ b/tests/built_in_-/success/cli.args
@@ -1,0 +1,2 @@
+eval
+tests/built_in_-/success/input.nix

--- a/tests/built_in_-/success/input.nix
+++ b/tests/built_in_-/success/input.nix
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2022 Kevin Amado <kamadorueda@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+1 - 2 - 3

--- a/tests/built_in_-/success/output.log
+++ b/tests/built_in_-/success/output.log
@@ -1,0 +1,3 @@
+[INFO]: value = Int(
+    -4,
+)


### PR DESCRIPTION
low hanging fruit ...

move build_math_fn to separate file?

lets rename `built-in +` to `built-in add`? (etc)
`-` is used for subtraction and negation
`!` cannot be used in filenames

rename `built_in` to `builtin`? (like in nix)

```rs

        match (&*lhs, &*rhs) {
            (Value::String { parts: lhs_value }, Value::String { parts: rhs_value }) => {
                let mut new_value = LinkedList::<StringPart>::new();
                for val in lhs_value {
                    new_value.push_back(*val);
                    // error[E0507]: cannot move out of `*val` which is behind a shared reference
                    // move occurs because `*val` has type `StringPart`, which does not implement the `Copy` trait
                }
                for val in rhs_value {
                    new_value.push_back(*val);
                }
                Ok(Rc::new(Value::String { parts: new_value }))
            }
```

```
error[E0507]: cannot move out of `*val` which is behind a shared reference
   --> src/interpreter/runtime.rs:273:41
    |
273 |                     new_value.push_back(*val);
    |                                         ^^^^ move occurs because `*val` has type `StringPart`, which does not implement the `Copy` trait
```

implement copy trait in nixel?