### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ version = "3"
 [dependencies.log]
 default-features = false
 features = ["std"]
-version = "0"
+version = "0.4"
 
 [dependencies.nixel]
 default-features = false


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.